### PR TITLE
resolve possible null pointer dereference

### DIFF
--- a/lib/db_temp.cpp
+++ b/lib/db_temp.cpp
@@ -100,8 +100,8 @@ void db_temp::newItem()
 				tr("Preset Template values"), QString());
 	if (dlg->exec()) {
 		temp = new pki_temp(ic->currentPkiItem());
-		temp->pkiSource = generated;
 		if (temp) {
+			temp->pkiSource = generated;
 			if (runTempDlg(temp)) {
 				insertPKI(temp);
 				createSuccess(temp);


### PR DESCRIPTION
[lib/db_temp.cpp:104] -> [lib/db_temp.cpp:103]: (warning) Either the condition 'if(temp)' is redundant or there is possible null pointer dereference: temp.