### PR TITLE
Attribute size is validated in number of characters, not bytes

### DIFF
--- a/lib/x509name.cpp
+++ b/lib/x509name.cpp
@@ -237,12 +237,12 @@ QString x509name::checkLength() const
 			continue;
 		entry = getEntry(i);
 		if (tab->minsize > entry.size()) {
-			warn += QObject::tr("%1 is shorter than %2 bytes: '%3'").
+			warn += QObject::tr("%1 is shorter than %2 characters: '%3'").
 				arg(OBJ_nid2ln(n)).arg(tab->maxsize).arg(entry);
 			warn += "\n";
 		}
 		if ((tab->maxsize != -1) && (tab->maxsize < entry.size())) {
-			warn += QObject::tr("%1 is longer than %2 bytes: '%3'").
+			warn += QObject::tr("%1 is longer than %2 characters: '%3'").
 				arg(OBJ_nid2ln(n)).arg(tab->maxsize).arg(entry);
 			warn += "\n";
 		}


### PR DESCRIPTION
From RFC 5280, "Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile", "4.1.2.4. Issuer":

> **The type of the component AttributeValue** is determined by the AttributeType; 
> **in general it will be a DirectoryString.**

From ITU-T Rec. X.680 (11/2008), "Information technology – Abstract Syntax Notation One (ASN.1): Specification of basic notation", "51.5 Size constraint":

> 51.5 Size constraint
> ...
> 51.5.4 The **unit of measure depends on the parent type**, as follows:
> Type               Unit of measure
> bit                  string bit
> octet              string octet
> **character     string character**
> set-of             component value
> sequence-of   component value