### PR TITLE
Add includes required in FreeBSD to use in6_addr, AF_INET and AF_INET6.

### DIFF
--- a/lib/ipvalidator.h
+++ b/lib/ipvalidator.h
@@ -13,6 +13,11 @@
 #include <QString>
 #include <QValidator>
 
+#ifdef __FreeBSD__
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
+
 /* Validating IPv4/6 is not as trivial as thought.
  * - The QHostAddress class requires the network library
  *   and i don't want to add many megabytes for this validator


### PR DESCRIPTION
I'm maintaining the FreeBSD port of xca.

The latest version requires the attached patch to successfully compile on FreeBSD.

I included this patch in the ports collection.

Could this change be merged?