### PR TITLE
Resolve gcc 9/10 new warnings.

### DIFF
--- a/lib/db.cpp
+++ b/lib/db.cpp
@@ -64,7 +64,7 @@ void db::init_header(db_header_t *db, int ver, int len, enum pki_type type,
 	db->type = xhtons(type);
 	db->version = xhtons(ver);
 	db->flags = 0;
-	strncpy(db->name, name.toUtf8(), NAMELEN);
+	strncpy(db->name, name.toUtf8(), NAMELEN-1);
 	db->name[NAMELEN-1] = '\0';
 }
 
@@ -225,7 +225,7 @@ void db::rename(enum pki_type type, QString name, QString n)
 	if (find(type, name) != 0) {
 		throw errorEx(QObject::tr("DB: Entry to rename not found: %1").arg(name));
 	}
-	strncpy(head.name, n.toUtf8(), NAMELEN);
+	strncpy(head.name, n.toUtf8(), NAMELEN-1);
 	head.name[NAMELEN-1] = '\0';
 	file.seek(head_offset);
 	ret = file.write((char*)&head, sizeof(head));

--- a/lib/exception.h
+++ b/lib/exception.h
@@ -32,6 +32,12 @@ class errorEx
 			msg = e.msg;
 			info = e.info;
 		}
+		errorEx &operator = (const errorEx &e)
+		{
+			msg = e.msg;
+			info = e.info;
+			return *this;
+		}
 		void appendString(QString s)
 		{
 			msg = msg + " " + s;

--- a/lib/pkcs11_lib.h
+++ b/lib/pkcs11_lib.h
@@ -68,6 +68,11 @@ class slotid
 		lib = l;
 		id = i;
 	}
+	slotid(const slotid &other)
+	{
+		lib = other.lib;
+		id = other.id;
+	}
 	slotid &operator = (const slotid &other)
 	{
 		lib = other.lib;

--- a/lib/pki_key.cpp
+++ b/lib/pki_key.cpp
@@ -661,9 +661,7 @@ bool pki_key::SSH2_compatible() const
 	switch (getKeyType()) {
 #ifndef OPENSSL_NO_EC
 	case EVP_PKEY_EC:
-		if (ecParamNid() != NID_X9_62_prime256v1)
-			break;
-		/* fall */
+		return ecParamNid() == NID_X9_62_prime256v1;
 #endif
 	case EVP_PKEY_RSA:
 	case EVP_PKEY_DSA:

--- a/lib/x509rev.h
+++ b/lib/x509rev.h
@@ -135,6 +135,12 @@ class x509revList : public QList<x509rev>
 				append(r);
 			}
 		}
+		x509revList &operator = (const x509revList &r)
+		{
+			QList<x509rev>::operator=(r);
+			merged = r.merged;
+			return *this;
+		}
 		bool sqlUpdate(QVariant caId);
 };
 #endif


### PR DESCRIPTION
Hi Christian,
This PR suppresses new gcc warnings. See commit comments for details.

There are still deprecated declaration warnings (using Qt 5.13). However fixing them requires to know which minimum version and release of Qt you would like to support:
- `QListWidget::isItemSelected()`/`QListWidget::setItemSelected()` should be replaced by `QListWidgetItem::isSelected()`/`QListWidgetItem::setSelected()`. The latters are only available since Qt 4.2.
- `QFontMetrics::width()` should be replaced by `QFontMetrics::horizontalAdvance()`. Available since Qt 5.11.
- `QSqlError::setDriverText()` should be replaced by `QSqlError` constructor. The signature of this constructor (and associated methods) are not the same in Qt 4 and Qt 5.