### PR TITLE
Feature: Provide docker container for XCA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: minimal
+
+services:
+    - docker
+
+env:
+    global:
+        - PARALLELMFLAGS="-j4"
+    matrix:
+        - OPENSSL_VERSION=0.9.8zh OPENSSL_SHA1=3ff71636bea85a99f4d76a10d119c09bda0421e3 OPENSSL_BUILD_PARALLEL=NO
+        - OPENSSL_VERSION=1.0.2u  OPENSSL_SHA1=740916d79ab0d209d2775277b1c6c3ec2f6502b2
+        - OPENSSL_VERSION=1.1.0l  OPENSSL_SHA1=6e3507b29e2630f56023887d1f7d7ba1f584819b
+        - OPENSSL_VERSION=1.1.1d  OPENSSL_SHA1=056057782325134b76d1931c48f2c7e6595d7ef4
+
+script:
+    - docker build --rm 
+        --build-arg USER_ID=`id -u` 
+        --build-arg PARALLELMFLAGS=$PARALLELMFLAGS
+        --build-arg OPENSSL_VERSION=$OPENSSL_VERSION
+        --build-arg OPENSSL_SHA1=$OPENSSL_SHA1
+        --build-arg OPENSSL_BUILD_PARALLEL=$OPENSSL_BUILD_PARALLEL
+        --tag xca .
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,72 @@
+ARG REGISTRY_PREFIX=''
+ARG CODENAME=bionic
+
+FROM ${REGISTRY_PREFIX}ubuntu:${CODENAME} as builder
+
+RUN set -x \
+	&& apt update \
+	&& apt upgrade -y \
+	&& apt install --yes --no-install-recommends \
+		build-essential \
+		autotools-dev \
+		automake \
+		pkg-config \
+                libltdl-dev \
+		ca-certificates \
+		curl \
+		libqt4-dev \
+		libqt4-sql-sqlite \
+		x11-apps 
+
+ARG PARALLELMFLAGS=-j2
+
+ARG BUILD_DIR=/tmp/build
+
+ARG DUMB_INIT_VERSION=1.2.2
+RUN set -x \
+	&& mkdir -p ${BUILD_DIR} \
+	&& cd ${BUILD_DIR} \
+	&& curl -fSL -s -o dumb-init-${DUMB_INIT_VERSION}.tar.gz https://github.com/Yelp/dumb-init/archive/v${DUMB_INIT_VERSION}.tar.gz \
+	&& tar -xf dumb-init-${DUMB_INIT_VERSION}.tar.gz \
+	&& cd dumb-init-${DUMB_INIT_VERSION} \
+	&& make "$PARALLELMFLAGS" \
+	&& chmod +x dumb-init \
+	&& mv dumb-init /usr/local/bin/dumb-init \
+	&& dumb-init --version \
+	&& cd \
+	&& rm -rf ${BUILD_DIR}
+
+ARG OPENSSL_VERSION=1.1.1d
+ARG OPENSSL_SHA1=056057782325134b76d1931c48f2c7e6595d7ef4
+ARG OPENSSL_BUILD_PARALLEL=YES
+RUN set -x \
+	&& mkdir -p ${BUILD_DIR} \
+	&& cd ${BUILD_DIR} \
+	&& curl -fSL -s -o openssl-${OPENSSL_VERSION}.tar.gz https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+	&& echo "${OPENSSL_SHA1} openssl-${OPENSSL_VERSION}.tar.gz" | sha1sum -c - \
+	&& tar -xf openssl-${OPENSSL_VERSION}.tar.gz \
+	&& cd openssl-${OPENSSL_VERSION} \
+	&& ./config shared --prefix=/usr/local --openssldir=/usr/local \
+	&& if [ "${OPENSSL_BUILD_PARALLEL}" == "YES" ] ; then make "$PARALLELMFLAGS" ; else make ; fi \
+	&& make install \
+	&& cd \
+	&& rm -rf ${BUILD_DIR}
+
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
+	
+COPY . ${BUILD_DIR}
+RUN set -x \
+	&& cd ${BUILD_DIR} \
+	&& ./bootstrap \
+	&& ./configure \
+	&& make "$PARALLELMFLAGS" \
+	&& make install \
+	&& cd \
+	&& rm -rf ${BUILD_DIR}
+
+ARG USER_ID=1000
+RUN set -x \
+	&& useradd -u "$USER_ID" -ms /bin/bash user 
+
+ENTRYPOINT ["dumb-init", "--", "xca"]
+

--- a/INSTALL.docker
+++ b/INSTALL.docker
@@ -1,0 +1,69 @@
+
+This is a short overview of how to build and run XCA using docker.
+
+Install docker
+==============
+
+To install docker, follow the instructions provided at
+	https://docs.docker.com/install/
+
+Build XCA container
+===================
+
+Use the following command to build XCA container:
+
+	docker build --rm --build-arg USER_ID=`id -u` --tag xca .
+
+This will build a container named "xca" using default configuration.
+
+Build options
+-------------
+
+There are some options to customize build. Use dockers "--build-arg"
+option to add options.
+
+CODENAME              : code name of ubuntu version
+                        example: --build-arg CODENAME=bionic
+USER_ID               : id of user "user" inside of container
+                        example: --build-arg USER_ID=`id -u`
+PARALLELMFLAGS        : make flags for parralel build
+                        example: --build-arg PARALLELMFLAGS=-j2
+OPENSSL_VERSION       : version of OpenSSL
+		        example: --build-arg OPENSSL_VERIONS=1.1.1d
+OPENSSL_SHA1          : sha1 checksum of OpenSSL package
+                        example: --build-arg OPENSSL_SHA1=056057782325134b76d1931c48f2c7e6595d7ef4
+OPENSSL_BUILD_PARALLEL: enable/disable parallel build of OpenSSL
+                        example: --build-arg OPENSSL_BUILD_PARALLEL=YES
+                        note: some (older) versions of OpenSSL do not support parallel build
+
+Run XCA
+=======
+
+Once the container is built, run it using the following command:
+
+	docker run --rm -it --user `id -u` --network=host \
+		-e DISPLAY=$DISPLAY -e "QT_X11_NO_MITSHM=1" \
+		xca 
+
+Share local directory
+---------------------
+
+Use docker volumes to share a local directory. This might be useful to store data base files.
+
+	mkdir -p ./some_local_directory
+	docker run --rm -it --user `id -u` --network=host \
+		-e DISPLAY=$DISPLAY -e "QT_X11_NO_MITSHM=1" \
+		-v ./some_local_directory:/backup \
+		xca
+
+This makes ./some_local_directory accessible in the container as /backup.
+
+Run bash
+--------
+
+For debugging purposes container can be started in bash mode:
+
+	docker run --rm -it --user `id -u` --network=host \
+		-e DISPLAY=$DISPLAY -e "QT_X11_NO_MITSHM=1" \
+		--entrypoint dumb-init xca -- bash
+ 


### PR DESCRIPTION
This feature provides the following changes:

* adds a Dockerfile to build against specified versions of openssl
* enables travis matrix build

To build the container use

    docker build --rm --build-arg USER_ID=`id -u` --tag xca .

To run xca use

    docker run --rm -it --user `id -u` --network=host \
      -e DISPLAY=$DISPLAY -e "QT_X11_NO_MITSHM=1" xca

Once travis is enabled, matrix build is provided. You will find an example at https://travis-ci.org/falk-werner/xca.  You might also want to add a badge to your README.md for build status. An example is provided at https://github.com/falk-werner/xca/tree/travis_badge.