### PR TITLE
Fix missing gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ xca_db_stat
 xca_db_stat.exe
 aclocal.m4
 autom4te.cache/
+config.cache
 config.log
 config.status
 configure

--- a/misc/.gitignore
+++ b/misc/.gitignore
@@ -1,3 +1,4 @@
 dn.txt
 eku.txt
 oids.txt
+variables.wxi


### PR DESCRIPTION
These are generated files, or ones that are potentially generated.

If you run `./configure -C` it'll generate config.cache