### PR TITLE
Close #213: configure.ac: add description to AC_DEFINE_UNQUOTED

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_INIT([X Certificate and Key management],
 	[http://xca.hohnstaedt.de])
 ITERATION="$(cd "$srcdir" && git describe 2>/dev/null | sed -n 's/.*-\(@<:@0-9@:>@*\)-g.*/.\1/p')"
 AC_SUBST([ITERATION])
-AC_DEFINE_UNQUOTED([VERSION_ITERATION], ["${ITERATION}"])
+AC_DEFINE_UNQUOTED([VERSION_ITERATION], ["${ITERATION}"], [Development iteration])
 AC_MSG_NOTICE([     ***************************************************])
 AC_MSG_NOTICE([     *   ${PACKAGE_NAME} ${PACKAGE_VERSION}${ITERATION}])
 AC_MSG_NOTICE([     ***************************************************])


### PR DESCRIPTION
Some distributions use the autoheader command to generate and
overwrite the local.h file.

In contrast to autoconf, autoheader insists on the "description"
argument in AC_DEFINE_UNQUOTED(), so add it.