### PR TITLE
Fix M1/Big Sur build

### DIFF
--- a/INSTALL.mac
+++ b/INSTALL.mac
@@ -1,5 +1,5 @@
 
-brew install pkg-config autoconf automake openssl qt libtool
+brew install pkg-config autoconf automake openssl qt@5 libtool
 
 cd xca-2.3.0
 ./configure && make

--- a/INSTALL.mac
+++ b/INSTALL.mac
@@ -16,7 +16,7 @@ brew install mariadb-connector-c postgresql unixodbc
       MYSQL_LIBDIR=$(pkg-config --variable=prefix libmariadb)/lib/mariadb \
       MYSQL_INCDIR=$(pkg-config --variable=prefix libmariadb)/include/mariadb/ \
       MYSQL_LIBS="-lmariadb" \
-      PSQL_PREFIX=/usr/local/Cellar/postgresql/12.4/ \
+      PSQL_PREFIX=$(brew --cellar postgresql)/12.4/ \
       ODBC_PREFIX=$(pkg-config --variable=prefix odbc)
 
 make sub-plugins

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,11 @@ case "$(${CXX} -dumpmachine)" in
       for d in $(find $(brew --cellar) -name 'pkgconfig' -type d); do
         PKG_CONFIG_PATH="${d}:${PKG_CONFIG_PATH}"
       done
+
+    # homebrew's libtool is not available via pkg-config. Add it manually:
+    CFLAGS="${CFLAGS} -I$(find $(brew --cellar libtool) -type d -name "include" | sort -n | tail -n 1)"
+    CXXFLAGS="${CXXFLAGS} -I$(find $(brew --cellar libtool) -type d -name "include" | sort -n | tail -n 1)"
+    LIBS="${LIBS} -L$(find $(brew --cellar libtool) -type d -name "lib" | sort -n | tail -n 1)"
     fi
     export DYLD_LIBRARY_PATH
     test "${MACOS_VERSION3}" || MACOS_VERSION3="$(sw_vers -productVersion)"

--- a/configure.ac
+++ b/configure.ac
@@ -55,9 +55,11 @@ case "$(${CXX} -dumpmachine)" in
     HOST=DARWIN
     CXXFLAGS="${CXXFLAGS} -pipe -gdwarf-2"
     LIBS="${LIBS} -framework IOKit -framework CoreFoundation"
-    for d in $(find /usr/local/Cellar -name 'pkgconfig' -type d); do
-      PKG_CONFIG_PATH="${d}:${PKG_CONFIG_PATH}"
-    done
+    if [[ $(brew --cellar) ]]; then
+      for d in $(find $(brew --cellar) -name 'pkgconfig' -type d); do
+        PKG_CONFIG_PATH="${d}:${PKG_CONFIG_PATH}"
+      done
+    fi
     export DYLD_LIBRARY_PATH
     test "${MACOS_VERSION3}" || MACOS_VERSION3="$(sw_vers -productVersion)"
     ;;


### PR DESCRIPTION
These patches contain tweaks that simplify compiling xca on M1 with Big Sur. If homebrew and the xca build dependencies are installed and the xca code resides on a case-sensitive volume, builds can be performed using these commands:

```
./bootstrap
./configure
make
```

Related to #247