### PR TITLE
Replace certificate while renewing

### DIFF
--- a/lib/db_x509.cpp
+++ b/lib/db_x509.cpp
@@ -837,6 +837,7 @@ void db_x509::certRenewal(QModelIndexList indexes)
 	CertExtend *dlg = NULL;
 	x509rev r;
 	bool doRevoke = false;
+	bool doReplace = false;
 
 	if (indexes.size() == 0)
 		return;
@@ -862,6 +863,7 @@ void db_x509::certRenewal(QModelIndexList indexes)
 			r = revoke->getRevocation();
 			delete revoke;
 		}
+		doReplace = dlg->replace->isChecked();
 		foreach(idx, indexes) {
 			oldcert = fromIndex<pki_x509>(idx);
 			if (!oldcert)
@@ -887,6 +889,10 @@ void db_x509::certRenewal(QModelIndexList indexes)
 			newcert->sign(signkey, oldcert->getDigest());
 			newcert = dynamic_cast<pki_x509 *>(insert(newcert));
 			createSuccess(newcert);
+
+			// delete old certificate if requested
+			if (doReplace)
+				deletePKI(idx);
 		}
 		if (doRevoke)
 			do_revoke(indexes, r);

--- a/ui/CertExtend.ui
+++ b/ui/CertExtend.ui
@@ -216,6 +216,16 @@
       <string>Revoke old certificate</string>
      </property>
      <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="replace">
+     <property name="text">
+      <string>Replace old certificate</string>
+     </property>
+     <property name="checked">
       <bool>true</bool>
      </property>
     </widget>


### PR DESCRIPTION
Hi, @chris2511 
I've added the checkbox into the certificate renewal UI. It allows deleting the old certificate while renewing it. Tested on my temporary db, works fine.

I also unchecked by-default the revoke-checkbox. My reasoning is that most of the time when one renews a certificate, its lifetime and subsequently validity are prolonged, therefore there is no need to revoke the old one as it is as trustworty as the new one. Apart from that, honestly saying I'm tired of always disabling this checkbox.