### PR TITLE
Reproducible Builds: Don't embed timestamps in xca.1.gz

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,7 +20,7 @@ include $(TOPDIR)/Rules.mak
 
 %.1.gz: %.1
 	@$(PRINT) "  MAN    [$(BASENAME)] $@"
-	gzip -9 <$^ >$@
+	gzip -n9 <$^ >$@
 
 xca.1: xca.1.head xca.1.options xca.1.tail
 	cat $^ > $@


### PR DESCRIPTION
An [Arch Linux rebuilder](https://reproducible.archlinux.org/api/v0/builds/134532/diffoscope) has flagged xca to contain a timestamp in the xca.1.gz file, setting the -n flag in gzip disables this feature. :)

```
│ ├── usr/share/man/man1/xca.1.gz
│ │ ├── filetype from file(1)
│ │ │ @@ -1 +1 @@
│ │ │ -gzip compressed data, last modified: Mon May 24 21:45:18 2021, max compression, from Unix
│ │ │ +gzip compressed data, last modified: Fri Jul  9 04:09:18 2021, max compression, from Unix
```

