### PR TITLE
Enables usage of aes_256_cbc for private key export

### DIFF
--- a/lib/pki_evp.cpp
+++ b/lib/pki_evp.cpp
@@ -699,7 +699,7 @@ bool pki_evp::pem(BioByteArray &b)
 		const EVP_CIPHER *algo = xport->match_all(F_CRYPT) ?
 			EVP_aes_256_cbc() : NULL;
 		pkey = decryptKey();
-		PEM_write_bio_PrivateKey(b, pkey, NULL,
+        PEM_write_bio_PrivateKey(b, pkey, algo,
 					 passwd.constUchar(), passwd.size(),
 					 NULL, NULL);
 		EVP_PKEY_free(pkey);


### PR DESCRIPTION
Bug was introduced in [commit](https://github.com/chris2511/xca/commit/be1a44d0a8529e18807c6ca2b784c41ca0787647)

In old version for encryption always used EVP_aes_256_cbc():
``` C++
PEM_write_bio_PrivateKey(b, pkey, EVP_aes_256_cbc(),
```
In current version it always NULL:
``` C++
PEM_write_bio_PrivateKey(b, pkey, NULL,
```
This mr fix this by using value proper local variable.