### PR TITLE
Add missing comma between two image names

### DIFF
--- a/widgets/XcaDialog.cpp
+++ b/widgets/XcaDialog.cpp
@@ -12,7 +12,7 @@
 
 // index = enum pki_type
 static const char * const PixmapMap[] = {
-  "" ":keyImg", ":csrImg", ":certImg", ":revImg", ":tempImg", "", ":scardImg",
+    "", ":keyImg", ":csrImg", ":certImg", ":revImg", ":tempImg", "", ":scardImg",
 };
 
 XcaDialog::XcaDialog(QWidget *parent, enum pki_type type, QWidget *w,


### PR DESCRIPTION
Before that "" was concatenated with second element so each
call by index to that array would be off by 1.

So, for example instead of ":certImg", ":csrImg" - was used.