### PR TITLE
Support importing ED25519 keys and signing with them, using PKCS#11 tokens

### DIFF
--- a/lib/opensc-pkcs11.h
+++ b/lib/opensc-pkcs11.h
@@ -364,6 +364,8 @@ typedef unsigned long ck_key_type_t;
 #define CKK_AES			(0x1f)
 #define CKK_BLOWFISH		(0x20)
 #define CKK_TWOFISH		(0x21)
+#define CKK_EC_EDWARDS		(0x40)
+#define CKK_EC_MONTGOMERY	(0x41)
 #define CKK_VENDOR_DEFINED	((unsigned long) (1 << 31))
 
 
@@ -664,6 +666,7 @@ typedef unsigned long ck_mechanism_type_t;
 #define CKM_ECDH1_DERIVE		(0x1050)
 #define CKM_ECDH1_COFACTOR_DERIVE	(0x1051)
 #define CKM_ECMQV_DERIVE		(0x1052)
+#define CKM_EDDSA			(0x1057)
 #define CKM_JUNIPER_KEY_GEN		(0x1060)
 #define CKM_JUNIPER_ECB128		(0x1061)
 #define CKM_JUNIPER_CBC128		(0x1062)


### PR DESCRIPTION
What works:
- Importing ED25519 Signature key from Yubikey token (OpenSC with openpgp driver, key generated via gpg)
- Creating self-signed certificate for CA, for Signature key from card
- Signing Certificates using new CA

I haven't tested other features, e.g. storing new certificate on card, so, they're probably broken