### PR TITLE
Use CMAKE_INSTALL_DOCDIR for docs location

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -102,7 +102,7 @@ if(SPHINX)
       install(DIRECTORY ${D}/html DESTINATION .doc)
     else()
       install(FILES ${HTML_DEST}
-              DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/${CMAKE_PROJECT_NAME}
+              DESTINATION ${CMAKE_INSTALL_DOCDIR}
     )
     endif()
   endif()


### PR DESCRIPTION
Lets packagers specify it instead of assuming it'll always be `<DATADIR>/doc` (e.g. `/usr/share/doc`).