### PR TITLE
PKCS12 encryption algorithm setting

### DIFF
--- a/lib/db_x509.cpp
+++ b/lib/db_x509.cpp
@@ -662,7 +662,8 @@ void db_x509::writePKCS12(pki_x509 *cert, XFile &file, bool chain) const
 			cert = signer;
 			signer = signer->getSigner();
 		}
-		p12->writePKCS12(file);
+		encAlgo encAlgo((QString) Settings["pkcs12_enc_algo"]);
+		p12->writePKCS12(file, encAlgo);
 	}
 	catch (errorEx &err) {
 		XCA_ERROR(err);

--- a/lib/pki_pkcs12.cpp
+++ b/lib/pki_pkcs12.cpp
@@ -173,7 +173,7 @@ QString encAlgo::name() const
 	return QString(encAlgo_nid == NID_undef ? "" : OBJ_nid2sn(encAlgo_nid));
 }
 
-int encAlgo::getEncAlgo() const
+int encAlgo::getEncAlgoNid() const
 {
 	return encAlgo_nid;
 }

--- a/lib/pki_pkcs12.cpp
+++ b/lib/pki_pkcs12.cpp
@@ -148,3 +148,42 @@ void pki_pkcs12::writePKCS12(XFile &file) const
 	PKCS12_free(pkcs12);
 	file.write(b);
 }
+
+
+const QList<int> encAlgo::all_encAlgos(
+	{ NID_pbe_WithSHA1And3_Key_TripleDES_CBC,
+	  NID_aes_256_cbc
+});
+
+int encAlgo::default_encAlgo(NID_pbe_WithSHA1And3_Key_TripleDES_CBC);
+
+encAlgo::encAlgo(int nid) : encAlgo_nid(nid)
+{
+}
+
+encAlgo::encAlgo(const QString &name) : encAlgo_nid(default_encAlgo)
+{
+	QString s(name);
+	encAlgo_nid = OBJ_txt2nid(CCHAR(s.remove(QChar(' '))));
+	ign_openssl_error();
+}
+
+QString encAlgo::name() const
+{
+	return QString(encAlgo_nid == NID_undef ? "" : OBJ_nid2sn(encAlgo_nid));
+}
+
+int encAlgo::getEncAlgo() const
+{
+	return encAlgo_nid;
+}
+
+const encAlgo encAlgo::getDefault()
+{
+	return encAlgo(default_encAlgo);
+}
+
+void encAlgo::setDefault(const QString &def)
+{
+	default_encAlgo = encAlgo(def).encAlgo_nid;
+}

--- a/lib/pki_pkcs12.cpp
+++ b/lib/pki_pkcs12.cpp
@@ -139,7 +139,7 @@ void pki_pkcs12::writePKCS12(XFile &file) const
 	}
 	pkcs12 = PKCS12_create(pass.data(), getIntName().toUtf8().data(),
 				key->decryptKey(), cert->getCert(), certstack,
-				0, NID_pbe_WithSHA1And3_Key_TripleDES_CBC,
+				NID_pbe_WithSHA1And3_Key_TripleDES_CBC, NID_pbe_WithSHA1And3_Key_TripleDES_CBC,
 				0, 0, 0);
 	BioByteArray b;
 	i2d_PKCS12_bio(b, pkcs12);

--- a/lib/pki_pkcs12.cpp
+++ b/lib/pki_pkcs12.cpp
@@ -118,7 +118,7 @@ pki_pkcs12::pki_pkcs12(const QString &fname)
 	pki_openssl_error();
 }
 
-void pki_pkcs12::writePKCS12(XFile &file) const
+void pki_pkcs12::writePKCS12(XFile &file, encAlgo &encAlgo) const
 {
 	Passwd pass;
 	PKCS12 *pkcs12;
@@ -137,9 +137,10 @@ void pki_pkcs12::writePKCS12(XFile &file) const
 		if (x && x != cert)
 			sk_X509_push(certstack, x->getCert());
 	}
+	int encAlgoNid = encAlgo.getEncAlgoNid();
 	pkcs12 = PKCS12_create(pass.data(), getIntName().toUtf8().data(),
 				key->decryptKey(), cert->getCert(), certstack,
-				NID_pbe_WithSHA1And3_Key_TripleDES_CBC, NID_pbe_WithSHA1And3_Key_TripleDES_CBC,
+				encAlgoNid, encAlgoNid,
 				0, 0, 0);
 	BioByteArray b;
 	i2d_PKCS12_bio(b, pkcs12);

--- a/lib/pki_pkcs12.cpp
+++ b/lib/pki_pkcs12.cpp
@@ -151,6 +151,7 @@ void pki_pkcs12::writePKCS12(XFile &file, encAlgo &encAlgo) const
 }
 
 
+// see https://www.rfc-editor.org/rfc/rfc8018 Appendix B.2 for possible encryption schemes
 const QList<int> encAlgo::all_encAlgos(
 	{ NID_pbe_WithSHA1And3_Key_TripleDES_CBC,
 	  NID_aes_256_cbc

--- a/lib/pki_pkcs12.h
+++ b/lib/pki_pkcs12.h
@@ -57,6 +57,6 @@ class pki_pkcs12: public pki_multi
 		{
 			return cert;
 		}
-		void writePKCS12(XFile &file) const;
+		void writePKCS12(XFile &file, encAlgo &encAlgo) const;
 };
 #endif

--- a/lib/pki_pkcs12.h
+++ b/lib/pki_pkcs12.h
@@ -13,6 +13,27 @@
 class pki_key;
 class pki_x509;
 
+class encAlgo
+{
+	private:
+	static int default_encAlgo;
+	int encAlgo_nid;
+
+	public:
+	static const QList<int> all_encAlgos;
+
+	encAlgo(int nid);
+	encAlgo(const QString &name);
+	encAlgo(const encAlgo &d) = default;
+	encAlgo& operator=(const encAlgo &d) = default;
+
+	QString name() const;
+	int getEncAlgo() const;
+
+	static void setDefault(const QString &def);
+	static const encAlgo getDefault();
+};
+
 class pki_pkcs12: public pki_multi
 {
 	Q_OBJECT

--- a/lib/pki_pkcs12.h
+++ b/lib/pki_pkcs12.h
@@ -28,7 +28,7 @@ class encAlgo
 	encAlgo& operator=(const encAlgo &d) = default;
 
 	QString name() const;
-	int getEncAlgo() const;
+	int getEncAlgoNid() const;
 
 	static void setDefault(const QString &def);
 	static const encAlgo getDefault();

--- a/lib/settings.cpp
+++ b/lib/settings.cpp
@@ -3,6 +3,7 @@
 #include "sql.h"
 #include "pki_key.h"
 #include "digest.h"
+#include "pki_pkcs12.h"
 #include "pki_export.h"
 
 #include <QDir>
@@ -34,6 +35,7 @@ settings::settings()
 	defaul["string_opt"] = "MASK:0x2002";
 	defaul["workingdir"] = "";
 	defaul["default_hash"] = digest::getDefault().name();
+	defaul["pkcs12_enc_algo"] = encAlgo::getDefault().name();
 	defaul["ical_expiry"] = "1W";
 	defaul["cert_expiry"] = "80%";
 	defaul["serial_len"] = "64";
@@ -59,6 +61,8 @@ void settings::setAction(const QString &key, const QString &value)
 		ASN1_STRING_set_default_mask_asc((char*)CCHAR(value));
 	else if (key == "default_hash")
 		digest::setDefault(value);
+	else if (key == "pkcs12_enc_algo")
+		encAlgo::setDefault(value);
 	else if (key == "defaultkey")
 		keyjob::defaultjob = keyjob(value);
 	else if (key == "optionflags") {

--- a/ui/Options.ui
+++ b/ui/Options.ui
@@ -57,6 +57,20 @@
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <item>
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>PKCS12 encryption algorithm</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="pkcs12EncBox" name="pkcs12EncAlgo"/>
+         </item>
+        </layout>
+       </item>
+       <item>
         <layout class="QHBoxLayout">
          <item>
           <widget class="QLabel" name="label">
@@ -424,14 +438,19 @@ Especially EC and DSA are only defined with SHA1 in the PKCS#11 specification.</
  </widget>
  <customwidgets>
   <customwidget>
+   <class>focusCombo</class>
+   <extends>QComboBox</extends>
+   <header>widgets/FocusCombo.h</header>
+  </customwidget>
+  <customwidget>
    <class>hashBox</class>
    <extends>QComboBox</extends>
    <header>widgets/hashBox.h</header>
   </customwidget>
   <customwidget>
-   <class>focusCombo</class>
+   <class>pkcs12EncBox</class>
    <extends>QComboBox</extends>
-   <header>widgets/FocusCombo.h</header>
+   <header>widgets/pkcs12EncBox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/widgets/CMakeLists.txt
+++ b/widgets/CMakeLists.txt
@@ -25,6 +25,8 @@ MW_help.cpp		TempTreeView.h		v3ext.cpp
 MW_menu.cpp		X509SuperTreeView.cpp	v3ext.h
 MainWindow.cpp		X509SuperTreeView.h	validity.cpp
 MainWindow.h		XcaApplication.cpp	validity.h
+pkcs12EncBox.h
+pkcs12EncBox.cpp
 )
 
 list(TRANSFORM xca_sources PREPEND ${PROJECT_SOURCE_DIR}/widgets/)

--- a/widgets/Options.cpp
+++ b/widgets/Options.cpp
@@ -147,6 +147,7 @@ int Options::exec()
 	Settings["disable_netscape"] = disableNetscape->checkState();
 
 	Settings["default_hash"] = hashAlgo->current().name();
+    	Settings["pkcs12_enc_algo"] = pkcs12EncAlgo->current().name();
 	Settings["mandatory_dn"] = getDnString(extDNlist);
 	Settings["explicit_dn"] = getDnString(expDNlist);
 	Settings["string_opt"] = string_opts[mbstring->currentIndex()];

--- a/widgets/pkcs12EncBox.cpp
+++ b/widgets/pkcs12EncBox.cpp
@@ -1,0 +1,60 @@
+/* vi: set sw=4 ts=4:
+ *
+ * Copyright (C) 2007 - 2015 Christian Hohnstaedt.
+ *
+ * All rights reserved.
+ */
+
+#include "pkcs12EncBox.h"
+#include <QDebug>
+
+pkcs12EncBox::pkcs12EncBox(QWidget *parent)
+	:QComboBox(parent)
+{
+	setupAllEncAlgos();
+}
+
+const encAlgo pkcs12EncBox::current() const
+{
+	return encAlgo(currentText());
+}
+
+void pkcs12EncBox::setCurrent(const encAlgo &md)
+{
+	int idx = findText(md.name());
+	if (idx != -1) {
+		setCurrentIndex(idx);
+		wanted_encAlgo = "";
+	} else {
+		wanted_encAlgo = md.name();
+	}
+}
+
+void pkcs12EncBox::setupEncAlgos(QList<int> nids)
+{
+	QString md = currentText();
+
+	if (!wanted_encAlgo.isEmpty())
+		md = wanted_encAlgo;
+	clear();
+	foreach(int nid, encAlgo::all_encAlgos) {
+		if (nids.contains(nid))
+			addItem(encAlgo(nid).name());
+	}
+	setEnabled(count() > 0);
+	setDefaultEncAlgo();
+	if (!md.isEmpty())
+		setCurrent(encAlgo(md));
+	else
+		setDefaultEncAlgo();
+}
+
+void pkcs12EncBox::setupAllEncAlgos()
+{
+	setupEncAlgos(encAlgo::all_encAlgos);
+}
+
+void pkcs12EncBox::setDefaultEncAlgo()
+{
+	setCurrent(encAlgo::getDefault());
+}

--- a/widgets/pkcs12EncBox.h
+++ b/widgets/pkcs12EncBox.h
@@ -1,0 +1,28 @@
+/* vi: set sw=4 ts=4:
+ *
+ * Copyright (C) 2007 - 2011 Christian Hohnstaedt.
+ *
+ * All rights reserved.
+ */
+
+#ifndef __PKCS12_ENC_BOX_H
+#define __PKCS12_ENC_BOX_H
+
+#include <QComboBox>
+#include "lib/pki_pkcs12.h"
+
+class pkcs12EncBox: public QComboBox
+{
+	Q_OBJECT
+	private:
+		QString wanted_encAlgo;
+	public:
+		pkcs12EncBox(QWidget *parent);
+		const encAlgo current() const;
+		void setCurrent(const encAlgo &md);
+		void setupEncAlgos(QList<int> nids);
+		void setupAllEncAlgos();
+		void setDefaultEncAlgo();
+};
+
+#endif


### PR DESCRIPTION
This pull request adds the ability to configure the encryption algorithm used for cert and key encryption in a PKCS12 container.

According to PKCS5 v2.0, the AES-256-CBC algorithm is not allowed as an encryption scheme. It has been added in v2.1. But there are legacy systems such as Android, which are not capable of decrypting such a PKCS12 container. The code which has been present before these changes used PDE-3Key-3DES for the cert encryption, but the default in openssl (AES-256-CBC) for key encryption. This merge request sets both schemes to the same value, so if 3DES is selected in the options, then both key and cert get encrypted that way. By doing that importing a PKCS12 file on Android works.