### PR TITLE
Refresh supported hashes after key generation

### DIFF
--- a/widgets/NewX509.cpp
+++ b/widgets/NewX509.cpp
@@ -691,6 +691,7 @@ void NewX509::on_genKeyBut_clicked()
 	if (dlg->exec()) {
 		db_key *keys = Database.model<db_key>();
 		keys->newKey(dlg->getKeyJob(), dlg->keyDesc->text());
+		switchHashAlgo();
 	}
 	delete dlg;
 }


### PR DESCRIPTION
Generating a new key in the x509 certificate creation dialog does not refresh the supported hash algorithms. The following error is produced after trying to use an unsupported hash algorithm, e.g., ED25519 with any algorithm:
```
The following error occurred:
(8pki_x509[]:...)
error:1010F08A:elliptic curve routines:pkey_ecd_ctrl:invalid digest type

(...\xca\lib\pki_x509.cpp:574)
``` 
Fixed by refreshing available algorithms immediately after generating a new key.