### PR TITLE
Fix vertical text alignment in the tree views

### DIFF
--- a/lib/db_base.cpp
+++ b/lib/db_base.cpp
@@ -451,7 +451,7 @@ QVariant db_base::data(const QModelIndex &index, int role) const
 		case Qt::DecorationRole:
 			return item->getIcon(hd);
 		case Qt::TextAlignmentRole:
-			return hd->isNumeric() ? Qt::AlignRight : Qt::AlignLeft;
+			return int((hd->isNumeric() ? Qt::AlignRight : Qt::AlignLeft) | Qt::AlignVCenter);
 		case Qt::BackgroundRole:
 			return item->bg_color(hd);
 		case Qt::UserRole:


### PR DESCRIPTION
This was bugging me.
| Before:      | After: |
| ----------- | ----------- |
| ![VAlignTop](https://github.com/chris2511/xca/assets/1297574/adceac42-0831-414a-bbe8-fe7f82c71281) | ![VAlignCenter](https://github.com/chris2511/xca/assets/1297574/e284dc8c-16e6-4a59-b087-9e00700e0e6a) |

P.S.: Thank you for this great tool that keeps me away from the abomination called openssl.