### PR TITLE
Fix a use-after-free crash

### DIFF
--- a/lib/db_x509.cpp
+++ b/lib/db_x509.cpp
@@ -765,13 +765,15 @@ void db_x509::certRenewal(QModelIndexList indexes)
 			newcert->sign(signkey, oldcert->getDigest());
 			newcert = dynamic_cast<pki_x509 *>(insert(newcert));
 			createSuccess(newcert);
-
-			// delete old certificate if requested
-			if (doReplace)
-				deletePKI(idx);
 		}
 		if (doRevoke)
 			do_revoke(indexes, r);
+
+		// delete old certificates if requested
+		if (doReplace)
+			foreach(idx, indexes)
+				if (fromIndex<pki_x509>(idx))
+					deletePKI(idx);
 	}
 	catch (errorEx &err) {
 		XCA_ERROR(err);


### PR DESCRIPTION
Hi Christian,

There has been a Fedora BZ report about an xca 2.5.0 crash: https://bugzilla.redhat.com/show_bug.cgi?id=2259477

I presumed commit https://github.com/chris2511/xca/commit/43e1b336d23e7512b246da142c78307baad4cbff would do the trick, but this is not sufficient.

Issue https://github.com/chris2511/xca/issues/493 would probably be fixed with this PR.

See the commit message for an explanation.

Cheers,
Patrick