### PR TITLE
Add option to export PKCS#12 in "legacy" mode (MACALG of SHA1)

### DIFF
--- a/lib/db_x509.cpp
+++ b/lib/db_x509.cpp
@@ -661,7 +661,7 @@ void db_x509::writePKCS12(pki_x509 *cert, XFile &file, bool chain) const
 			signer = signer->getSigner();
 		}
 		encAlgo encAlgo((QString) Settings["pkcs12_enc_algo"]);
-		p12->writePKCS12(file, encAlgo);
+		p12->writePKCS12(file, encAlgo, Settings["pkcs12_legacy_macalg"]);
 	}
 	catch (errorEx &err) {
 		XCA_ERROR(err);

--- a/lib/pki_pkcs12.h
+++ b/lib/pki_pkcs12.h
@@ -57,7 +57,7 @@ class pki_pkcs12: public pki_multi
 		{
 			return cert;
 		}
-		void writePKCS12(XFile &file, encAlgo &encAlgo) const;
+		void writePKCS12(XFile &file, encAlgo &encAlgo, bool legacy = false) const;
 		void collect_properties(QMap<QString, QString> &prp) const;
 };
 #endif

--- a/ui/Options.ui
+++ b/ui/Options.ui
@@ -85,6 +85,13 @@
         </layout>
        </item>
        <item>
+        <widget class="QCheckBox" name="pkcs12LegacyMACALG">
+         <property name="text">
+          <string>Export PKCS#12 with legacy MAC ALG (SHA1)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="suppress">
          <property name="text">
           <string>Suppress success messages</string>

--- a/widgets/Options.cpp
+++ b/widgets/Options.cpp
@@ -54,6 +54,7 @@ Options::Options(QWidget *parent)
 	onlyTokenHashes->setCheckState(Settings["only_token_hashes"]);
 	disableNetscape->setCheckState(Settings["disable_netscape"]);
 	adapt_explicit_subj->setCheckState(Settings["adapt_explicit_subj"]);
+	pkcs12LegacyMACALG->setCheckState(Settings["pkcs12_legacy_macalg"]);
 
 	QStringList units;
 	QString x = Settings["ical_expiry"];
@@ -151,7 +152,8 @@ int Options::exec()
 	Settings["disable_netscape"] = disableNetscape->checkState();
 
 	Settings["default_hash"] = hashAlgo->current().name();
-    	Settings["pkcs12_enc_algo"] = pkcs12EncAlgo->current().name();
+	Settings["pkcs12_enc_algo"] = pkcs12EncAlgo->current().name();
+	Settings["pkcs12_legacy_macalg"] = pkcs12LegacyMACALG->checkState();
 	Settings["mandatory_dn"] = getDnString(extDNlist);
 	Settings["explicit_dn"] = getDnString(expDNlist);
 	Settings["string_opt"] = string_opts[mbstring->currentIndex()];


### PR DESCRIPTION
I have recently run into an issue when supporting older windows servers. PKCS#12 certs exported in 2.4.0 will import fine but certs exported from 2.5.0 complain about an invalid password. From research the difference is the MAC Algorithm default change between using openssl 1 and 3.

This pull request adds the ability to export PKCS#12 certs with a SHA1 MAC Algorithm (instead of the SHA256 that is now used by default with openssl >= 3).

It generates a certificate that is equivalent of using the following CLI command:

```
openssl pkcs12 -macalg SHA1 -nomaciter -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -export -in .\test-certbag.pem -out .\test-legacy.pfx
```

Potentially fixes:
- #383
- #474 
- #481 
- #506 
- #509 

I can confirm that the certificates exported with my test compiled version of XCA can import into Windows Server 2012 when using the "new" option flag.