### PR TITLE
Fix dockerimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ ARG CODENAME=jammy
 
 FROM ${REGISTRY_PREFIX}ubuntu:${CODENAME} as builder
 
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN set -x \
 	&& apt update \
 	&& apt upgrade -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,10 @@ RUN set -x \
 	&& cmake --build BUILD ${PARALLELMFLAGS} \
 	&& cmake --install BUILD \
 	&& cd \
+	&& mv ${BUILD_DIR}/misc/docker_start.sh / \
 	&& rm -rf ${BUILD_DIR}
 
-ARG USER_ID=1000
-RUN set -x \
-	&& useradd -u "$USER_ID" -ms /bin/bash user
+RUN mkdir -p /home/user && chmod 0777 /home/user
 
-ENTRYPOINT ["xca"]
+ENTRYPOINT ["/docker_start.sh"]
 

--- a/INSTALL.docker
+++ b/INSTALL.docker
@@ -12,7 +12,7 @@ Build XCA container
 
 Use the following command to build XCA container:
 
-	docker build --rm --build-arg USER_ID=`id -u` --tag xca .
+	docker build --rm --tag xca .
 
 This will build a container named "xca" using default configuration.
 
@@ -24,8 +24,6 @@ option to add options.
 
 CODENAME              : code name of ubuntu version
                         example: --build-arg CODENAME=jammy
-USER_ID               : id of user "user" inside of container
-                        example: --build-arg USER_ID=`id -u`
 PARALLELMFLAGS        : make flags for parralel build
                         example: --build-arg PARALLELMFLAGS=-j2
 
@@ -34,7 +32,7 @@ Run XCA
 
 Once the container is built, run it using the following command:
 
-	docker run --rm -it --user `id -u` --network=host \
+	docker run --rm -it -e USER_ID=`id -u` --network=host \
 		-e DISPLAY=$DISPLAY -e "QT_X11_NO_MITSHM=1" \
 		xca
 
@@ -44,9 +42,21 @@ Share local directory
 Use docker volumes to share a local directory. This might be useful to store data base files.
 
 	mkdir -p ./some_local_directory
-	docker run --rm -it --user `id -u` --network=host \
+	docker run --rm -it -e USER_ID=`id -u` --network=host \
 		-e DISPLAY=$DISPLAY -e "QT_X11_NO_MITSHM=1" \
 		-v ./some_local_directory:/backup \
 		xca
 
 This makes ./some_local_directory accessible in the container as /backup.
+
+Run over X-Forwarding with SSH
+------------------------------
+
+To run with X-Forwarding over an SSH connection, you need to mount volumes and fix OpenGL usage:
+
+	docker run --rm -it --network=host \
+		-e DISPLAY=$DISPLAY -e "QT_X11_NO_MITSHM=1" -e LIBGL_ALWAYS_SOFTWARE=1 \
+		-v $HOME/.Xauthority:/home/user/.Xauthority \
+		xca
+
+Note: the environment variable USER_ID doesn't need to be set, since USER_ID is derived from ownership of .Xauthority file.

--- a/INSTALL.docker
+++ b/INSTALL.docker
@@ -52,7 +52,7 @@ This makes ./some_local_directory accessible in the container as /backup.
 Run over X-Forwarding with SSH
 ------------------------------
 
-To run with X-Forwarding over an SSH connection, you need to mount volumes and fix OpenGL usage:
+To run with X-Forwarding over an SSH connection, you can mount .Xauthority. If the application windows doesn't show up, likely you also want to switch to OpenGL done in software:
 
 	docker run --rm -it --network=host \
 		-e DISPLAY=$DISPLAY -e "QT_X11_NO_MITSHM=1" -e LIBGL_ALWAYS_SOFTWARE=1 \

--- a/misc/docker_start.sh
+++ b/misc/docker_start.sh
@@ -19,7 +19,7 @@ else
         echo "using USER_ID from .Xauthority: $USER_ID"
     else
         USER_ID=$default_userid
-        echo "using default: $USER_ID"
+        echo "using default USER_ID: $USER_ID"
     fi
 fi
 

--- a/misc/docker_start.sh
+++ b/misc/docker_start.sh
@@ -25,4 +25,4 @@ fi
 
 useradd -u "$USER_ID" -M -s /bin/bash user
 
-exec su user -c "xca $@"
+exec su user -c "xca $*"

--- a/misc/docker_start.sh
+++ b/misc/docker_start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+default_userid=1000
+
+file_path="/home/user/.Xauthority"
+
+if [ -n "$USER_ID" ]; then
+    if [[ "$USER_ID" =~ ^[0-9]+$ ]] && [ "$USER_ID" -gt 0 ]; then
+        echo "using USER_ID from environment: $USER_ID"
+    else
+        echo "USER_ID from environment not numeric, aborting"
+        exit 1    
+    fi
+else
+    if [ -e "$filepath" ]; then
+        USER_ID=$(stat -c "%u" "$filepath")
+        echo "using USER_ID from .Xauthority: $USER_ID"
+    else
+        USER_ID=$default_userid
+        echo "using default: $USER_ID"
+    fi
+fi
+
+useradd -u "$USER_ID" -M -s /bin/bash user
+
+exec su user -c "xca $@"


### PR DESCRIPTION
I have an use case with different users connect to a virtual machine with SSH and X-forwarding runnig XCA in Docker.

This PR introduces a small fix to the Dockerfile (since build was broken), as well as a change to allow controlling the userid XCA runs at container start time instead of build time. This enables different users to run the same container image. Also documentation is adapted to reflect these changes. Additionally, documentations points out how to circumvent issues regarding OpenGL, when running with X-forwarding.