### PR TITLE
#550: Fix compiling tests issue by providing -pthread link flag.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_test(NAME testxca COMMAND testxca)
 set_tests_properties(testxca PROPERTIES LABELS gui)
 add_dependencies(tests testxca)
 target_link_libraries(testxca ${ASAN_LIB} ${QT}::Test xcalib)
+target_link_options(testxca PRIVATE -pthread)
 
 if (APPLE)
   target_link_libraries(testxca


### PR DESCRIPTION
Added Pthread link flag to the test Cmakelist based on @chris2511 advise.
