### PR TITLE
How to load templates if missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ To build XCA you need:
  - Install: `sudo cmake --install build`
  - Or install local and copy later as root: `DESTDIR=DEST cmake --install build --prefix /usr`
 
+ - After running the application, you will need to import .xca files from the misc folder to have the templates.  Click on Templates and then Import. Navigate to misc folder and import the templates 
+
 ### Apple macos
 
 - Install the dependencies


### PR DESCRIPTION
The CMake build seems to not load the template files.  This short instruction will help the user load the template files.