### PR TITLE
Fix BioByteArray when char is not signed

### DIFF
--- a/lib/BioByteArray.cpp
+++ b/lib/BioByteArray.cpp
@@ -18,7 +18,7 @@ BioByteArray::BioByteArray(const BIGNUM *bn, int bits)
 	store.resize(BN_num_bytes(bn));
 	BN_bn2bin(bn, (unsigned char *)store.data());
 	openssl_error();
-	if (store.size() > 0 && (char)store[0] < 0)
+	if (store.size() > 0 && (unsigned char)store[0] >= 0x80)
 		store.prepend('\0');
 	if (len > 0 && store.size() < len)
 		store.prepend(len - store.size(), 0);


### PR DESCRIPTION
char can be signed or unsigned depending on the arch and compiler flags. Use unsigned char explicitly to behave consistently.

Fixes 70788535732e Consolidate Bignum2ByteArray conversion implementations