### PR TITLE
Fixes Broken ED25519 OpenSSH Private Key Exports

### DIFF
--- a/lib/pki_evp.cpp
+++ b/lib/pki_evp.cpp
@@ -938,14 +938,20 @@ void pki_evp::write_SSH2_ed25519_private(BIO *b, const EVP_PKEY *pkey) const
 {
 #ifndef OPENSSL_NO_EC
 	static const char data0001[] = { 0, 0, 0, 1};
-	char buf_nonce[8];
+	// padding required to bring private key up to required block size for encryption
+	// elected to just add fixed padding as the size of the binary data should not change due to the fixed keysizes
+	static const char padding[] = { 1, 2, 3, 4, 5 };
+	char buf_nonce[4];
 	QByteArray data, priv, pubfull;
 
 	pubfull = SSH2publicQByteArray(true);
 	RAND_bytes((unsigned char*)buf_nonce, sizeof buf_nonce);
 	priv.append(buf_nonce, sizeof buf_nonce);
+	priv.append(buf_nonce, sizeof buf_nonce);
 	priv += pubfull;
 	ssh_key_QBA2data(ed25519PrivKey(pkey) + ed25519PubKey(), &priv);
+	ssh_key_QBA2data("", &priv); // comment (blank)
+	priv.append(padding, sizeof padding);
 
 	data = "openssh-key-v1";
 	data.append('\0');


### PR DESCRIPTION
Resolves a few issues in the binary format of exported OpenSSH Private Key files, namely:

- The nonce was generated as a single 64bit random string instead of a 32bit string repeated twice.
- Null comment was omitted
- Padding was omitted

After implementing these changes and building XCA, I was able to confirm ED25519 keys are now working with OpenSSH:
![image](https://github.com/user-attachments/assets/594d9d6f-a311-4a57-ae56-cdfec89d030e)

fixes #658 